### PR TITLE
Adding start to docker build updater!

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,7 @@ jobs:
       dockerfile_matrix: ${{ steps.dockerfile_check.outputs.dockerfile_matrix }}
       dockerhierarchy_matrix: ${{ steps.dockerhierarchy_check.outputs.dockerhierarchy_matrix }}
       dockerfilelist_matrix: ${{ steps.dockerfilelist_check.outputs.dockerfilelist_matrix }}
+      dockerbuild_matrix: ${{ steps.dockerbuild_check.outputs.dockerbuild_matrix }}
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v2
@@ -33,6 +34,13 @@ jobs:
         root: ./tests
         parser: dockerfilelist
 
+    - name: Test dockerbuild matrix uptodate GitHub Action
+      uses: ./
+      id: dockerbuild_check
+      with: 
+        root: ./tests/ubuntu/clang
+        parser: dockerbuild
+
   view:
     needs:
       - test
@@ -51,4 +59,9 @@ jobs:
       - name: Check Docker Hierarchy Result
         env:
           result: ${{ needs.test.outputs.dockerhierarchy_matrix }}
+        run: echo ${result}
+        
+      - name: Check Docker Build Result
+        env:
+          result: ${{ needs.test.outputs.dockerbuild_matrix }}
         run: echo ${result}

--- a/cli/dockerbuild.go
+++ b/cli/dockerbuild.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/DataDrake/cli-ng/v2/cmd"
+	"github.com/vsoch/uptodate/parsers/docker"
+	"github.com/vsoch/uptodate/utils"
+)
+
+// Args and flags for generate
+type DockerBuildArgs struct {
+	Root []string `zero:"true" desc:"A root directory to parse."`
+}
+
+type DockerBuildFlags struct{}
+
+// Dockerfile updates one or more Dockerfile
+var DockerBuild = cmd.Sub{
+	Name:  "dockerbuild",
+	Alias: "db",
+	Short: "Generate a matrix of builds for GitHub Actions or Similar.",
+	Flags: &DockerBuildFlags{},
+	Args:  &DockerBuildArgs{},
+	Run:   RunDockerBuild,
+}
+
+func init() {
+	cmd.Register(&DockerBuild)
+}
+
+// RunDockerfile updates one or more Dockerfile
+func RunDockerBuild(r *cmd.Root, c *cmd.Sub) {
+
+	args := c.Args.(*DockerBuildArgs)
+
+	// If no root provided, assume parsing the PWD
+	if len(args.Root) == 0 {
+		args.Root = []string{utils.GetPwd()}
+	}
+
+	// Print the logo!
+	fmt.Println(utils.GetLogo() + "                     dockerbuild\n")
+
+	// Update the dockerfiles with a Dockerfile parser
+	parser := docker.DockerBuildParser{}
+	parser.Parse(args.Root[0])
+
+}

--- a/config/uptodate.go
+++ b/config/uptodate.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"github.com/mitchellh/mapstructure"
 	"gopkg.in/yaml.v3"
 	"io/ioutil"
@@ -86,7 +85,6 @@ type Conf struct {
 }
 
 func Load(yamlfile string) Conf {
-	fmt.Println(yamlfile)
 	yamlContent, err := ioutil.ReadFile(yamlfile)
 	if err != nil {
 		log.Printf("yamlFile.Get err   #%v ", err)

--- a/config/uptodate.go
+++ b/config/uptodate.go
@@ -1,7 +1,9 @@
 package config
 
 import (
-	"gopkg.in/yaml.v2"
+	"fmt"
+	"github.com/mitchellh/mapstructure"
+	"gopkg.in/yaml.v3"
 	"io/ioutil"
 	"log"
 )
@@ -17,19 +19,77 @@ type DockerHierarchy struct {
 	Container Container `yaml:"container"`
 }
 
+// DockerBuild holds one or more build args
+// We'd have to separate these later anyway
+type DockerBuild struct {
+	BuildArgs map[string]BuildArg `yaml:"build_args"`
+}
+
+// BuildArg expects metadata for building from a variable, spack, or other
+type BuildArg struct {
+	Name     string            `yaml:"name,omitempty"`
+	Type     string            `yaml:"type,omitempty"`
+	StartAt  string            `yaml:"startat,omitempty"`
+	Versions []string          `yaml:"versions,omitempty"`
+	Values   []string          `yaml:"values,omitempty"`
+	Filter   []string          `yaml:"filter,omitempty"`
+	Skips    []string          `yaml:"skips,omitempty"`
+	Params   map[string]string `yaml:"params,omitempty"`
+}
+
+// read the config and return a config type
+func readConfig(yamlStr []byte) Conf {
+
+	// First unmarshall into generic structure
+	var data map[string]interface{}
+	err := yaml.Unmarshal(yamlStr, &data)
+	if err != nil {
+		log.Fatalf("Unmarshal: %v\n", err)
+	}
+
+	// A config can hold multiple keyed sections
+	c := Conf{}
+
+	// If we have a dockerhierarchy, add it
+	if item, ok := data["dockerhierarchy"]; ok {
+		c.DockerHierarchy = convertDockerHierarchy(item)
+	}
+
+	// If we have a docker build, need to parse items
+	if item, ok := data["dockerbuild"]; ok {
+		buildArgs := item.(map[string]interface{})
+		if builditem, ok := buildArgs["build_args"]; ok {
+			c.DockerBuild = convertDockerBuild(builditem)
+		}
+	}
+	return c
+}
+
+// convertDockerHierarchy maps the dockerhierarchy portion to a DockerHierarchy
+func convertDockerHierarchy(item interface{}) DockerHierarchy {
+	hier := DockerHierarchy{}
+	mapstructure.Decode(item, &hier)
+	return hier
+}
+
+// convertDockerBuild maps the dockerbuild build params to a DockerBuild
+func convertDockerBuild(item interface{}) DockerBuild {
+	build := map[string]BuildArg{}
+	mapstructure.Decode(item, &build)
+	db := DockerBuild{BuildArgs: build}
+	return db
+}
+
 type Conf struct {
 	DockerHierarchy DockerHierarchy `yaml:"dockerhierarchy,omitempty"`
+	DockerBuild     DockerBuild     `yaml:"dockerbuild,omitempty"`
 }
 
 func Load(yamlfile string) Conf {
-	c := Conf{}
+	fmt.Println(yamlfile)
 	yamlContent, err := ioutil.ReadFile(yamlfile)
 	if err != nil {
 		log.Printf("yamlFile.Get err   #%v ", err)
 	}
-	err = yaml.Unmarshal(yamlContent, &c)
-	if err != nil {
-		log.Fatalf("Unmarshal: %v", err)
-	}
-	return c
+	return readConfig(yamlContent)
 }

--- a/docs/docs/user-guide/user-guide.md
+++ b/docs/docs/user-guide/user-guide.md
@@ -8,7 +8,7 @@ in your repository and help you keep this up to date (hence the name!) This mean
  - A **Dockerfile** Updater: will look for all Dockerfiles, find `FROM` lines, and make sure we are using the most up to date hash. We do not advance the tag itself (e.g., 18.04 will not be updated to 20.04) but just the sha256 sum, in the case that there are security updates, etc.
  - A **Docker Hierarchy**: is a structure that has some top level folder identified by an `uptodate.yaml` file, which is described [here](https://vsoch.github.io/uptodate/docs/#/user-guide/user-guide?id=uptodate-yaml). Within this folder are subfolders that correspond to tags, and the tool looks for new tags, and generates you a template Dockerfile to build if there are. 
  - A **Dockerfile List**: updater will simply find all your Dockerfiles, and list them or provide them in a json output for a GitHub action for further parsing.
- - A **Docker Build**: (under development) will provide a matrix of builds to pipe into a GitHub Action.
+ - A **Docker Build**: provides a matrix of builds to pipe into a GitHub Action.
  
 For all of the above, you can run the tool manually on the command line, or as a GitHub action.
 For the last (Docker Build) the builds aren't currently performed for you (and you can [request this](https://github.com/vsoch/uptodate/issues) if you'd like it)
@@ -194,10 +194,42 @@ $ ./uptodate dockerfilelist
 ### Docker Build
 
 Docker build will be similar to the Docker Hierarchy updater in that it reads an `uptodate.yaml`
-and then generates one or more build matrices for it. The matrices can be parsed into
+and then generates one or more build matrices for it. The matrices include all versions or other variables
+that you've specified, along with the Dockerfile that are discovered under the root where
+the `uptodate.yaml` is. The matrices can be parsed into
 a GitHub action to drive further container builds using one or more base images.
+For example, let's say that we start with this configuration file:
 
-**under development**
+```yaml
+dockerbuild:
+  build_args:
+    # This is an example of a manual build arg, versions are required
+    llvm_version:
+      versions:
+       - "4.0.0"
+       - "5.0.1"
+       - "6.0.0"
+
+    # This will be parsed by the Dockerfile parser, name is the container name
+    ubuntu_version:
+      name: ubuntu
+      type: container
+      startat: "16.04"
+      filter: 
+        - "^[0-9]+[.]04$" 
+      skips:
+      - "17.04"
+      - "19.04"
+```
+
+You'll see the primary section of interest is under `dockerbuild`, and under this
+we have two build args. There are three `type` of build args:
+
+
+ - *manual*: meaning you define a name and a list of versions or values, no extra parsing or updating done!
+ - *container*: meaning you define similar fields to if you were asking to update Dockerfile froms - a container name, startat (version), filter, and versions to skip. If you include a tag with your container, we will simply update digests (and keep the same tag) so you'll get a much smaller matrix.
+ - *spack*: not developed yet, will get the "latest" version from spack.
+ 
 
 ### GitHub Action
 

--- a/docs/docs/user-guide/user-guide.md
+++ b/docs/docs/user-guide/user-guide.md
@@ -203,12 +203,17 @@ For example, let's say that we start with this configuration file:
 ```yaml
 dockerbuild:
   build_args:
-    # This is an example of a manual build arg, versions are required
+    # This is an example of a manual build arg, versions (or values) are required
     llvm_version:
       versions:
        - "4.0.0"
        - "5.0.1"
        - "6.0.0"
+
+    # This is an example of a spack build arg, the name is the package
+    abyss_version:
+      name: abyss
+      type: spack
 
     # This will be parsed by the Dockerfile parser, name is the container name
     ubuntu_version:
@@ -223,12 +228,12 @@ dockerbuild:
 ```
 
 You'll see the primary section of interest is under `dockerbuild`, and under this
-we have two build args. There are three `type` of build args:
+we have theww build args. There are three `type` of build args:
 
 
  - *manual*: meaning you define a name and a list of versions or values, no extra parsing or updating done!
+ - *spack*: derive a list of versions from spack, with the same options to start at, filter, skip, etc. The data is parsed from [the spack packages interface](https://spack.github.io/packages/) that is updated nightly from spack develop.
  - *container*: meaning you define similar fields to if you were asking to update Dockerfile froms - a container name, startat (version), filter, and versions to skip. If you include a tag with your container, we will simply update digests (and keep the same tag) so you'll get a much smaller matrix.
- - *spack*: not developed yet, will get the "latest" version from spack.
  
 
 ### GitHub Action

--- a/docs/docs/user-guide/user-guide.md
+++ b/docs/docs/user-guide/user-guide.md
@@ -5,7 +5,7 @@
 This is a Go library that will look for `Dockerfile`s and (eventually) other assets
 in your repository and help you keep this up to date (hence the name!) This means for:
 
- - A **Dockerfile** Updated: will look for all Dockerfiles, find `FROM` lines, and make sure we are using the most up to date hash. We do not advance the tag itself (e.g., 18.04 will not be updated to 20.04) but just the sha256 sum, in the case that there are security updates, etc.
+ - A **Dockerfile** Updater: will look for all Dockerfiles, find `FROM` lines, and make sure we are using the most up to date hash. We do not advance the tag itself (e.g., 18.04 will not be updated to 20.04) but just the sha256 sum, in the case that there are security updates, etc.
  - A **Docker Hierarchy**: is a structure that has some top level folder identified by an `uptodate.yaml` file, which is described [here](https://vsoch.github.io/uptodate/docs/#/user-guide/user-guide?id=uptodate-yaml). Within this folder are subfolders that correspond to tags, and the tool looks for new tags, and generates you a template Dockerfile to build if there are. 
  - A **Dockerfile List**: updater will simply find all your Dockerfiles, and list them or provide them in a json output for a GitHub action for further parsing.
  - A **Docker Build**: (under development) will provide a matrix of builds to pipe into a GitHub Action.

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,10 @@ require (
 	github.com/alecbcs/lookout v1.2.7
 	github.com/asottile/dockerfile v3.1.0+incompatible
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/mitchellh/mapstructure v1.3.1 // indirect
 	github.com/moby/buildkit v0.9.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )
 
 replace github.com/DataDrake/cuppa => github.com/autamus/cuppa v1.1.1-0.20210507175721-5e45e84fb3cd

--- a/go.sum
+++ b/go.sum
@@ -844,6 +844,7 @@ github.com/mitchellh/hashstructure v1.0.0/go.mod h1:QjSHrPWS+BGUVBYkbTZWEnOh3G1D
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5Y5bqfLA=
 github.com/mitchellh/mapstructure v1.3.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/moby/buildkit v0.8.1/go.mod h1:/kyU1hKy/aYCuP39GZA9MaKioovHku57N6cqlKZIaiQ=

--- a/parsers/common.go
+++ b/parsers/common.go
@@ -10,5 +10,14 @@ type Result struct {
 	Identifier string `json:"id,omitempty"`
 }
 
+// A BuildResult needs more information (e.g., versions) to be given to a build matrix
+type BuildResult struct {
+	Name       string `json:"name,omitempty"`
+	Filename   string `json:"filename,omitempty"`
+	Parser     string `json:"parser,omitempty"`
+	Identifier string `json:"id,omitempty"`
+	Version    string `json:"version,omitempty"`
+}
+
 // VersionRegex matches a major and minor, optional third group (not semver)
 var VersionRegex = "[0-9]+[.][0-9]+(?:[.][0-9]+)?"

--- a/parsers/common.go
+++ b/parsers/common.go
@@ -12,11 +12,16 @@ type Result struct {
 
 // A BuildResult needs more information (e.g., versions) to be given to a build matrix
 type BuildResult struct {
-	Name       string `json:"name,omitempty"`
-	Filename   string `json:"filename,omitempty"`
-	Parser     string `json:"parser,omitempty"`
-	Identifier string `json:"id,omitempty"`
-	Version    string `json:"version,omitempty"`
+	Name      string            `json:"name,omitempty"`
+	Filename  string            `json:"filename,omitempty"`
+	Parser    string            `json:"parser,omitempty"`
+	BuildArgs map[string]string `json:"buildargs,omitempty"`
+}
+
+// BuildVariable holds a key (name) and one or more values to parameterize over
+type BuildVariable struct {
+	Name   string
+	Values []string
 }
 
 // VersionRegex matches a major and minor, optional third group (not semver)

--- a/parsers/docker/docker.go
+++ b/parsers/docker/docker.go
@@ -1,0 +1,128 @@
+package docker
+
+// Base functions for docker used by different updaters
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	lookout "github.com/alecbcs/lookout/update"
+	"github.com/vsoch/uptodate/utils"
+)
+
+// GetVersions of existing container within user preferences
+func GetVersions(container string, filters []string, startAtVersion string, skipVersions []string) []string {
+
+	// Get tags for current container image
+	tagsUrl := "https://crane.ggcr.dev/ls/" + container
+	response := utils.GetRequest(tagsUrl)
+	tags := strings.Split(response, "\n")
+
+	// We look for tags based on filters (this is an OR between them)
+	filter := "(" + strings.Join(filters, "|") + ")"
+	isVersionRegex, _ := regexp.Compile(filter)
+
+	// Derive list of those that match minimally a minor, major
+	versions := []string{}
+
+	// Also don't add until we hit the start at version, given defined
+	doAdd := true
+	if startAtVersion != "" {
+		doAdd = false
+	}
+
+	// The tags should already be sorted
+	for _, text := range tags {
+
+		// Have we hit the requested start version, and can add now?
+		if startAtVersion != "" && startAtVersion == text && !doAdd {
+			doAdd = true
+		}
+
+		// Is the tag in the list to skip?
+		if utils.IncludesString(text, skipVersions) {
+			continue
+		}
+
+		// If we are adding, great! Add here to our list
+		if doAdd && isVersionRegex.MatchString(text) {
+			versions = append(versions, text)
+		}
+	}
+	return versions
+}
+
+// UpdateFrom updates a single From, and returns an Update
+func UpdateFrom(fromValue []string) Update {
+
+	// We will return an update, empty if none
+	update := Update{}
+
+	// This is the full container name, e.g., ubuntu:16.04
+	container := fromValue[0]
+
+	// Keep the original for later comparison
+	original := strings.Join(fromValue, " ")
+
+	// Variable statements we can't reliably update
+	isVariable := strings.Contains(container, "$")
+	if isVariable {
+		return update
+	}
+
+	// We want to keep track of having a hash and/or tag
+	hasHash := false
+	hasTag := false
+
+	// First remove any digest from the container
+	if strings.Contains(container, "@") {
+		parts := strings.SplitN(container, "@", 2)
+		container = parts[0]
+		hasHash = true
+	}
+
+	// Now extract any tag from the container
+	tag := "latest"
+	if strings.Contains(container, ":") {
+		parts := strings.SplitN(container, ":", 2)
+		container = parts[0]
+		tag = parts[1]
+		hasTag = true
+	} else {
+		fmt.Printf("No tag specified for %s, will default to latest.\n", container)
+	}
+
+	// If it has a hash but no digest, we can't correctly parse
+	if hasHash && !hasTag {
+		fmt.Printf("Cannot parse %s, has a hash but no tag, cannot be looked up.\n", container)
+		return update
+	}
+
+	// Get the updated container hash for the tag
+	url := container + ":" + tag
+	out, found := lookout.CheckUpdate("docker://" + url)
+
+	if found {
+		// Prepare the updated string, the result.Name is digest
+		result := *out
+		updated := url + "@" + result.Name
+
+		// Add original content back
+		for _, extra := range fromValue[1:] {
+			updated += " " + extra
+		}
+
+		// If the updated version is different from the original, update
+		if updated != original {
+
+			// TODO I've never seen a multi-line FROM, but this will need
+			// adjustment if one exists to replace a range of lines
+			update = Update{Original: original, Updated: updated}
+
+		} else {
+			fmt.Println("Cannot find container URI", url)
+		}
+	}
+	return update
+}

--- a/parsers/docker/dockerbuild.go
+++ b/parsers/docker/dockerbuild.go
@@ -1,0 +1,87 @@
+package docker
+
+// The Dockerfile parser is optimized to find and update FROM statements
+
+import (
+	/*	"encoding/json"*/
+	"fmt"
+	"github.com/vsoch/uptodate/config"
+	"github.com/vsoch/uptodate/parsers"
+	"github.com/vsoch/uptodate/utils"
+	"log"
+	"reflect"
+)
+
+// BuildArg is a key with one or more values (can be versions)
+type BuildArg struct {
+
+	// Versions are optional, and only valid for manual
+	Name   string   `json:"name"`
+	Values []string `json:"values"`
+}
+
+// BuildArgSpack expects metadata for building from spack
+type BuildArgSpack struct {
+	Type     string   `json:"type"`
+	Name     string   `json:"name,omitempty"`
+	StartAt  string   `json:"startat,omitempty"`
+	Versions []string `json:"versions,omitempty"`
+	Filter   []string `json:"filter,omitempty"`
+	Skips    []string `json:"skips,omitempty"`
+	AsView   bool     `json:"view,omitempty"`
+}
+
+// BuildArgContainer updates container tags, etc.
+type BuildArgContainer struct {
+	Type     string   `json:"type"`
+	Name     string   `json:"name,omitempty"`
+	StartAt  string   `json:"startat,omitempty"`
+	Versions []string `json:"versions,omitempty"`
+	Filter   []string `json:"filter,omitempty"`
+	Skips    []string `json:"skips,omitempty"`
+}
+
+// DockerBuild holds one or more build args
+type DockerBuild struct {
+	BuildArgs []map[string]interface{}
+}
+
+// DockerBuildParser holds one or more Docker Builds
+type DockerBuildParser struct {
+	Builds []DockerBuild
+}
+
+// Entrypoint to parse one or more Docker build matrices
+func (s *DockerBuildParser) Parse(path string) error {
+
+	// Find config files in path and don't allow prefixes
+	paths, _ := utils.RecursiveFind(path, "uptodate.yaml", false)
+
+	// Look at each found path, parse into build matrix
+	for _, subpath := range paths {
+		conf := config.Load(subpath)
+
+		// We must have a DockerBuild to continue! This checks against an empty one
+		if reflect.DeepEqual(conf.DockerBuild, config.DockerBuild{}) {
+			log.Fatal("dockerbuild section not detected in config!")
+		}
+
+		// Prepare a matrix of json results
+		results := parsers.BuildResult{}
+
+		for key, buildarg := range conf.DockerBuild.BuildArgs {
+
+			// If it has a type, it either is that type, or we map to another type
+			// TODO each of these needs to be parsed, then output matrix!
+			if buildarg.Type == "container" {
+				fmt.Println("Found container build arg", key, buildarg)
+			} else if buildarg.Type == "spack" {
+				fmt.Println("Found spack build arg", key, buildarg)
+			} else {
+				fmt.Println("Found regular build arg", key, buildarg)
+			}
+		}
+		fmt.Println(results)
+	}
+	return nil
+}

--- a/parsers/spack/spack.go
+++ b/parsers/spack/spack.go
@@ -1,0 +1,100 @@
+package spack
+
+// The spack Parser can parse Json from the spack packages repository
+
+import (
+	"github.com/vsoch/uptodate/utils"
+	"regexp"
+	"strings"
+)
+
+// A SpackAlias has a name and alias_for
+type SpackAlias struct {
+	Name     string `json:"name"`
+	AliasFor string `json:"alias_for"`
+}
+
+type SpackVersion struct {
+	Name   string `json:"name"`
+	Sha256 string `json:"sha256"`
+}
+
+type SpackConflict struct {
+	Name        string `json:"name"`
+	Spec        string `json:"spec"`
+	Description string `json:"description"`
+}
+
+// A SpackPackage matches the format of spack.github.io/packages/data/packages/<package>.json
+type SpackPackage struct {
+	Name         string       `json:"name"`
+	Aliases      []SpackAlias `json:"aliases"`
+	Versions     []SpackVersion
+	BuildSystem  string            `json:"build_system"`
+	Conflicts    []SpackConflict   `json:"conflicts"`
+	Variants     []SpackVariant    `json:"variants"`
+	Homepage     string            `json:"homepage"`
+	Patches      []SpackPatch      `json:"patches"`
+	Maintainers  []string          `json:"maintainers"`
+	Resources    interface{}       `json:"resources"`
+	Description  string            `json:"description"`
+	Dependencies []SpackDependency `json:"dependencies"`
+	DependentTo  []SpackDependency `json:"dependent_to"`
+}
+
+type SpackPatch struct {
+	Owner        string `json:"owner"`
+	Sha256       string `json:"sha256"`
+	Level        int    `json:"level"`
+	WorkingDir   string `json:"working_dir"`
+	RelativePath string `json:"relative_path"`
+	Version      string `json:"version"`
+}
+
+type SpackVariant struct {
+	Name        string      `json:"name"`
+	Default     interface{} `json:"default"`
+	Description string      `json:"description"`
+}
+
+type SpackDependency struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// Get Versions of a spack package relevant to a set of user preferences
+func (s *SpackPackage) GetVersions(filters []string, startAtVersion string, skipVersions []string) []string {
+
+	// Final list of versions we will provide
+	versions := []string{}
+
+	// We look for tags based on filters (this is an OR between them)
+	filter := "(" + strings.Join(filters, "|") + ")"
+	isVersionRegex, _ := regexp.Compile(filter)
+
+	// Also don't add until we hit the start at version, given defined
+	doAdd := true
+	if startAtVersion != "" {
+		doAdd = false
+	}
+
+	// The tags should already be sorted
+	for _, version := range s.Versions {
+
+		// Have we hit the requested start version, and can add now?
+		if startAtVersion != "" && startAtVersion == version.Name && !doAdd {
+			doAdd = true
+		}
+
+		// Is the tag in the list to skip?
+		if utils.IncludesString(version.Name, skipVersions) {
+			continue
+		}
+
+		// If we are adding, great! Add here to our list
+		if doAdd && isVersionRegex.MatchString(version.Name) {
+			versions = append(versions, version.Name)
+		}
+	}
+	return versions
+}

--- a/tests/ubuntu/clang/Dockerfile
+++ b/tests/ubuntu/clang/Dockerfile
@@ -1,0 +1,17 @@
+ARG UBUNTU_VERSION
+FROM ghcr.io/rse-radiuss/ubuntu:$UBUNTU_IMAGE
+
+# Version of LLVM
+# This is an example of a manual type of build arg
+ARG LLVM_VERSION
+
+# BUild args will persist in environment?
+ENV llvmver=$LLVM_VERSION
+ENV llvmtar=clang+llvm-${llvmver}-x86_64-linux-gnu-ubuntu-${UBUNTU_VERSION}
+ENV tarext=.tar.xz
+
+RUN wget -q --no-check-certificate http://releases.llvm.org/${llvmver}/${llvmtar}${tarext} && \
+    tar xf ${llvmtar}${tarext} && \
+    sudo cp -fR ${llvmtar}/* /usr && \
+    rm -rf ${llvmtar} && \
+    rm ${llvmtar}${tarext}

--- a/tests/ubuntu/clang/uptodate.yaml
+++ b/tests/ubuntu/clang/uptodate.yaml
@@ -7,6 +7,11 @@ dockerbuild:
        - "5.0.1"
        - "6.0.0"
 
+    # This is an example of a spack build arg, the name is the package
+    abyss_version:
+      name: abyss
+      type: spack
+
     # This will be parsed by the Dockerfile parser, name is the container name
     ubuntu_version:
       name: ubuntu

--- a/tests/ubuntu/clang/uptodate.yaml
+++ b/tests/ubuntu/clang/uptodate.yaml
@@ -1,0 +1,19 @@
+dockerbuild:
+  build_args:
+    # This is an example of a manual build arg, versions are required
+    llvm_version:
+      versions:
+       - "4.0.0"
+       - "5.0.1"
+       - "6.0.0"
+
+    # This will be parsed by the Dockerfile parser, name is the container name
+    ubuntu_version:
+      name: ubuntu
+      type: container
+      startat: "16.04"
+      filter: 
+        - "^[0-9]+[.]04$" 
+      skips:
+      - "17.04"
+      - "19.04"


### PR DESCRIPTION
This updated will allow the user to specify a config file with different kinds of build args, and it will generate the build matrix to pipe into a GitHub action. So far we have types for:

 - manual (e.g., some key and list of values_)
 - container (e.g., ubuntu and get me an updated set of tags
 - spack (not developed yet, but will get some version info from spack)