### PR TITLE
Adding ability to specify includes versions for spack/container args

### DIFF
--- a/config/uptodate.go
+++ b/config/uptodate.go
@@ -8,10 +8,11 @@ import (
 )
 
 type Container struct {
-	Name    string   `yaml:"name"`
-	Filter  []string `yaml:"filter,omitempty"`
-	StartAt string   `yaml:"startat,omitempty"`
-	Skips   []string `yaml:"skips,omitempty"`
+	Name     string   `yaml:"name"`
+	Filter   []string `yaml:"filter,omitempty"`
+	StartAt  string   `yaml:"startat,omitempty"`
+	Skips    []string `yaml:"skips,omitempty"`
+	Includes []string `yaml:"includes,omitempty"`
 }
 
 type DockerHierarchy struct {
@@ -33,6 +34,7 @@ type BuildArg struct {
 	Values   []string          `yaml:"values,omitempty"`
 	Filter   []string          `yaml:"filter,omitempty"`
 	Skips    []string          `yaml:"skips,omitempty"`
+	Includes []string          `yaml:"includes,omitempty"`
 	Params   map[string]string `yaml:"params,omitempty"`
 }
 

--- a/docs/docs/user-guide/user-guide.md
+++ b/docs/docs/user-guide/user-guide.md
@@ -152,25 +152,30 @@ then derive all the existing tags for ubuntu (and by default use semver or seman
 to decide whether to include tags) and create new Dockerfile folders for those that
 are missing. The reason we need the `uptodate.yaml` is to store preference about
 tags to skip, or more generally, a pattern to match. For containers with more complex
-names that don't map nicely to a folder, we can just write it there. Here is an example,
+names that don't map nicely to a folder, we can just write it there. Here is an example for the `dockerhierarchy` updater,
 with a few examples of filters you might use:
 
 ```yaml
-container:
-  name: ubuntu
-  filter: 
-    # Don't include anything that starts with arm
-    - "^((?!arm).)*$"
-    # include anything that starts with 3.9 (e.g., 3.9.1)
-    - "3.9*"
+dockerhierarchy:
+  container:
+    name: ubuntu
+    filter: 
+      # Don't include anything that starts with arm
+      - "^((?!arm).)*$"
+      # include anything that starts with 3.9 (e.g., 3.9.1)
+      - "3.9*"
 
-  # The earliest version that should be used
-  startat: 16.04
+    # The earliest version that should be used
+    startat: 16.04
 
-  # Skip these versions (e.g., not long term releases or LTS)
-  skips:
-    - "17.04"
-    - "19.04"
+    # Skip these versions (e.g., not long term releases or LTS)
+    skips:
+      - "17.04"
+      - "19.04"
+
+    # Include these versions no matter what
+    includes:
+     - "21.10"
 ```
 
 Not including a filter defaults to looking for a numerical (something that has

--- a/parsers/docker/docker.go
+++ b/parsers/docker/docker.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetVersions of existing container within user preferences
-func GetVersions(container string, filters []string, startAtVersion string, skipVersions []string) []string {
+func GetVersions(container string, filters []string, startAtVersion string, skipVersions []string, includeVersions []string) []string {
 
 	// Get tags for current container image
 	tagsUrl := "https://crane.ggcr.dev/ls/" + container
@@ -34,6 +34,12 @@ func GetVersions(container string, filters []string, startAtVersion string, skip
 
 	// The tags should already be sorted
 	for _, text := range tags {
+
+		// If it's in the list to include, include no matter what
+		if utils.IncludesString(text, includeVersions) {
+			versions = append(versions, text)
+			continue
+		}
 
 		// Have we hit the requested start version, and can add now?
 		if startAtVersion != "" && startAtVersion == text && !doAdd {

--- a/parsers/docker/dockerbuild.go
+++ b/parsers/docker/dockerbuild.go
@@ -59,7 +59,7 @@ func parseContainerBuildArg(key string, buildarg config.BuildArg) []parsers.Buil
 
 		// Otherwise we want to be generating a list of tags (versions)
 	} else {
-		versions := GetVersions(buildarg.Name, buildarg.Filter, buildarg.StartAt, buildarg.Skips)
+		versions := GetVersions(buildarg.Name, buildarg.Filter, buildarg.StartAt, buildarg.Skips, buildarg.Includes)
 		newVar := parsers.BuildVariable{Name: key, Values: versions}
 		vars = append(vars, newVar)
 
@@ -83,7 +83,7 @@ func parseSpackBuildArg(key string, buildarg config.BuildArg) []parsers.BuildVar
 	}
 
 	// Get versions based on user preferences
-	versions := pkg.GetVersions(buildarg.Filter, buildarg.StartAt, buildarg.Skips)
+	versions := pkg.GetVersions(buildarg.Filter, buildarg.StartAt, buildarg.Skips, buildarg.Includes)
 	newVar := parsers.BuildVariable{Name: key, Values: versions}
 	vars := []parsers.BuildVariable{newVar}
 	return vars

--- a/parsers/docker/hierarchy.go
+++ b/parsers/docker/hierarchy.go
@@ -34,13 +34,14 @@ import (
 
 // A DockerHierarchy holds a set of preferences for parsing docker hierarchies
 type DockerHierarchy struct {
-	Root           string
-	Path           string // path to uptodate.yaml
-	Container      string
-	Filters        []string
-	StartAtVersion string
-	SkipVersions   []string
-	tags           []string
+	Root            string
+	Path            string // path to uptodate.yaml
+	Container       string
+	Filters         []string
+	StartAtVersion  string
+	SkipVersions    []string
+	IncludeVersions []string
+	tags            []string
 }
 
 // Return the basename of the specific root
@@ -152,11 +153,12 @@ func (s *DockerHierarchyParser) Load(path string) {
 
 		// Create a new DockerHierarchy, set name and filters
 		hier := DockerHierarchy{Container: conf.DockerHierarchy.Container.Name,
-			Filters:        conf.DockerHierarchy.Container.Filter,
-			StartAtVersion: conf.DockerHierarchy.Container.StartAt,
-			SkipVersions:   conf.DockerHierarchy.Container.Skips,
-			Path:           subpath,
-			Root:           path}
+			Filters:         conf.DockerHierarchy.Container.Filter,
+			StartAtVersion:  conf.DockerHierarchy.Container.StartAt,
+			SkipVersions:    conf.DockerHierarchy.Container.Skips,
+			IncludeVersions: conf.DockerHierarchy.Container.Includes,
+			Path:            subpath,
+			Root:            path}
 
 		// Add the hierarchy to those we know about
 		s.Roots = append(s.Roots, hier)
@@ -173,7 +175,7 @@ func (s *DockerHierarchyParser) Update(dryrun bool) error {
 	for _, root := range s.Roots {
 
 		// Get all versions (tags) based on filters and user preferences
-		versions := GetVersions(root.Container, root.Filters, root.StartAtVersion, root.SkipVersions)
+		versions := GetVersions(root.Container, root.Filters, root.StartAtVersion, root.SkipVersions, root.IncludeVersions)
 
 		// At this point we have a list of versions we want.
 		// We now compare existing to those that need to be created

--- a/parsers/spack/spack.go
+++ b/parsers/spack/spack.go
@@ -63,7 +63,7 @@ type SpackDependency struct {
 }
 
 // Get Versions of a spack package relevant to a set of user preferences
-func (s *SpackPackage) GetVersions(filters []string, startAtVersion string, skipVersions []string) []string {
+func (s *SpackPackage) GetVersions(filters []string, startAtVersion string, skipVersions []string, includeVersions []string) []string {
 
 	// Final list of versions we will provide
 	versions := []string{}
@@ -80,6 +80,12 @@ func (s *SpackPackage) GetVersions(filters []string, startAtVersion string, skip
 
 	// The tags should already be sorted
 	for _, version := range s.Versions {
+
+		// If it's in the list to include, include no matter what
+		if utils.IncludesString(version.Name, includeVersions) {
+			versions = append(versions, version.Name)
+			continue
+		}
 
 		// Have we hit the requested start version, and can add now?
 		if startAtVersion != "" && startAtVersion == version.Name && !doAdd {


### PR DESCRIPTION
A user/writer of an uptodate.yaml should be able to specify starting at a particular
version, but also having an explicit list to include no matter what

Signed-off-by: vsoch <vsoch@users.noreply.github.com>