### PR TITLE
adding ability to skip containers with build args

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       dockerhierarchy_matrix: ${{ steps.dockerhierarchy_check.outputs.dockerhierarchy_matrix }}
       dockerfilelist_matrix: ${{ steps.dockerfilelist_check.outputs.dockerfilelist_matrix }}
       dockerbuild_matrix: ${{ steps.dockerbuild_check.outputs.dockerbuild_matrix }}
+      buildargskip_matrix: ${{ steps.buildargskip_check.outputs.dockerfilelist_matrix }}
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v2
@@ -34,6 +35,14 @@ jobs:
         root: ./tests
         parser: dockerfilelist
 
+    - name: Test dockerfile list with skipping build args
+      uses: ./
+      id: buildargskip_check
+      with: 
+        root: ./tests
+        parser: dockerfilelist
+        flags: "--no-build-args"
+
     - name: Test dockerbuild matrix uptodate GitHub Action
       uses: ./
       id: dockerbuild_check
@@ -54,6 +63,11 @@ jobs:
       - name: Check Dockerfile List Result
         env:
           result: ${{ needs.test.outputs.dockerfilelist_matrix }}
+        run: echo ${result}
+
+      - name: Check Dockerfile List Result skippin build args
+        env:
+          result: ${{ needs.test.outputs.buildargskip_matrix }}
         run: echo ${result}
 
       - name: Check Docker Hierarchy Result

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: false
     default: false
 
+  flags:
+    description: "Extra flags for the parser (e.g., --no-build-args for dockerfilelist)"
+    required: false
+    default: ""
+
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -33,5 +38,9 @@ branding:
 outputs:
   dockerfile_matrix:
     description: A matrix of Dockerfile changes with name and filename set to the Dockerfile name
-  dockerhiearchy_matrix:
+  dockerhierarchy_matrix:
     description: A matrix of new Dockerfiles and the corresponding tag (Name)
+  dockerfilelist_matrix:
+    description: A matrix of Dockerfiles listed with dockerfilelist
+  dockerbuild_matrix:
+    description: A matrix of Docker builds

--- a/cli/dockerfilelist.go
+++ b/cli/dockerfilelist.go
@@ -12,6 +12,7 @@ type DockerfileListArgs struct {
 }
 
 type DockerfileListFlags struct {
+	IncludeArgs bool `long:"no-build-args" desc:"Do not include Dockerfile with build args (defaults to false)"`
 }
 
 // Dockerfile updates one or more Dockerfile
@@ -32,6 +33,7 @@ func init() {
 func RunDockerfileList(r *cmd.Root, c *cmd.Sub) {
 
 	args := c.Args.(*DockerfileListArgs)
+	flags := c.Flags.(*DockerfileListFlags)
 
 	// If no root provided, assume parsing the PWD
 	if len(args.Root) == 0 {
@@ -40,6 +42,6 @@ func RunDockerfileList(r *cmd.Root, c *cmd.Sub) {
 
 	// Update the dockerfiles with a Dockerfile parser
 	parser := docker.DockerfileListParser{}
-	parser.Parse(args.Root[0])
+	parser.Parse(args.Root[0], flags.IncludeArgs)
 
 }

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,8 @@ if [ "${INPUT_DRY_RUN}" == "true" ]; then
     COMMAND="${COMMAND} --dry-run"
 fi
 
-COMMAND="${COMMAND} ${INPUT_ROOT}"
+# Add parser specific flags and the root
+COMMAND="${COMMAND} ${INPUT_FLAGS} ${INPUT_ROOT}"
 echo "${COMMAND}"
 
 ${COMMAND}

--- a/parsers/docker/dockerfilelist.go
+++ b/parsers/docker/dockerfilelist.go
@@ -16,22 +16,27 @@ type DockerfileListParser struct {
 }
 
 // AddDockerfile adds a Dockerfile to the Parser
-func (s *DockerfileListParser) AddDockerfile(root string, path string) {
+func (s *DockerfileListParser) AddDockerfile(root string, path string, includeArgs bool) {
 
 	// Create a new Dockerfile entry
 	dockerfile := Dockerfile{Path: path, Root: root}
+
+	// If we aren't including build args, skip if the Dockerfile has them
+	if !includeArgs && dockerfile.HasBuildArgs() {
+		return
+	}
 	s.Dockerfiles = append(s.Dockerfiles, dockerfile)
 }
 
 // Entrypoint to parse one or more Dockerfiles
-func (s *DockerfileListParser) Parse(path string) error {
+func (s *DockerfileListParser) Parse(path string, includeArgs bool) error {
 
 	// Find Dockerfiles in path and allow prefixes
 	paths, _ := utils.RecursiveFind(path, "Dockerfile", true)
 
 	// Add each path as a Dockerfile to the parser to update
 	for _, subpath := range paths {
-		s.AddDockerfile(path, subpath)
+		s.AddDockerfile(path, subpath, includeArgs)
 	}
 
 	// Keep track of updated count and set of results


### PR DESCRIPTION
Likely we will encounter a case of wanting to build/parse Dockerfile that have _defined_ build args, but for now I'm just adding a flag that indicates to skip build args (default is we don't) which assumes that a container with build args cannot just be built without needing to define said build args.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>