### PR TITLE
Adding support for endat version

### DIFF
--- a/config/uptodate.go
+++ b/config/uptodate.go
@@ -11,6 +11,7 @@ type Container struct {
 	Name     string   `yaml:"name"`
 	Filter   []string `yaml:"filter,omitempty"`
 	StartAt  string   `yaml:"startat,omitempty"`
+	EndAt    string   `yaml:"endat,omitempty"`
 	Skips    []string `yaml:"skips,omitempty"`
 	Includes []string `yaml:"includes,omitempty"`
 }
@@ -32,6 +33,7 @@ type BuildArg struct {
 	Key      string            `yaml:"key,omitempty"`
 	Type     string            `yaml:"type,omitempty"`
 	StartAt  string            `yaml:"startat,omitempty"`
+	EndAt    string            `yaml:"endat,omitempty"`
 	Versions []string          `yaml:"versions,omitempty"`
 	Values   []string          `yaml:"values,omitempty"`
 	Filter   []string          `yaml:"filter,omitempty"`

--- a/docs/docs/user-guide/user-guide.md
+++ b/docs/docs/user-guide/user-guide.md
@@ -250,6 +250,7 @@ dockerbuild:
       name: ubuntu
       type: container
       startat: "16.04"
+      endat: "20.04"
       filter: 
         - "^[0-9]+[.]04$" 
       skips:

--- a/parsers/common.go
+++ b/parsers/common.go
@@ -74,7 +74,7 @@ func HasSemanticVersions(contenders []string) bool {
 	return haveSemver
 }
 
-func GetVersions(contenders []string, filters []string, startAtVersion string, skipVersions []string, includeVersions []string) []string {
+func GetVersions(contenders []string, filters []string, startAtVersion string, endAtVersion string, skipVersions []string, includeVersions []string) []string {
 
 	// Final list of versions we will provide
 	versions := []string{}
@@ -116,6 +116,11 @@ func GetVersions(contenders []string, filters []string, startAtVersion string, s
 		// If we are adding, great! Add here to our list
 		if doAdd && isVersionRegex.MatchString(version) {
 			versions = append(versions, version)
+		}
+
+		// If we have an endat version and we reached it, break
+		if endAtVersion != "" && endAtVersion == version {
+			break
 		}
 	}
 	return versions

--- a/parsers/docker/build.go
+++ b/parsers/docker/build.go
@@ -66,7 +66,8 @@ func parseContainerBuildArg(key string, buildarg config.BuildArg) []parsers.Buil
 
 		// Otherwise we want to be generating a list of tags (versions)
 	} else {
-		versions := GetVersions(buildarg.Name, buildarg.Filter, buildarg.StartAt, buildarg.Skips, buildarg.Includes)
+		versions := GetVersions(buildarg.Name, buildarg.Filter, buildarg.StartAt, buildarg.EndAt,
+			buildarg.Skips, buildarg.Includes)
 		newVar := parsers.BuildVariable{Name: key, Values: versions}
 		vars = append(vars, newVar)
 
@@ -90,7 +91,7 @@ func parseSpackBuildArg(key string, buildarg config.BuildArg) []parsers.BuildVar
 	}
 
 	// Get versions based on user preferences
-	versions := pkg.GetVersions(buildarg.Filter, buildarg.StartAt, buildarg.Skips, buildarg.Includes)
+	versions := pkg.GetVersions(buildarg.Filter, buildarg.StartAt, buildarg.EndAt, buildarg.Skips, buildarg.Includes)
 	newVar := parsers.BuildVariable{Name: key, Values: versions}
 	vars := []parsers.BuildVariable{newVar}
 	return vars

--- a/parsers/docker/docker.go
+++ b/parsers/docker/docker.go
@@ -13,7 +13,8 @@ import (
 )
 
 // GetVersions of existing container within user preferences
-func GetVersions(container string, filters []string, startAtVersion string, skipVersions []string, includeVersions []string) []string {
+func GetVersions(container string, filters []string, startAtVersion string, endAtVersion string,
+	skipVersions []string, includeVersions []string) []string {
 
 	// Get tags for current container image
 	tagsUrl := "https://crane.ggcr.dev/ls/" + container
@@ -21,7 +22,7 @@ func GetVersions(container string, filters []string, startAtVersion string, skip
 	tags := strings.Split(response, "\n")
 	sort.Sort(sort.StringSlice(tags))
 
-	return parsers.GetVersions(tags, filters, startAtVersion, skipVersions, includeVersions)
+	return parsers.GetVersions(tags, filters, startAtVersion, endAtVersion, skipVersions, includeVersions)
 }
 
 // UpdateFrom updates a single From, and returns an Update

--- a/parsers/docker/hierarchy.go
+++ b/parsers/docker/hierarchy.go
@@ -39,6 +39,7 @@ type DockerHierarchy struct {
 	Container       string
 	Filters         []string
 	StartAtVersion  string
+	EndAtVersion    string
 	SkipVersions    []string
 	IncludeVersions []string
 	tags            []string
@@ -155,6 +156,7 @@ func (s *DockerHierarchyParser) Load(path string) {
 		hier := DockerHierarchy{Container: conf.DockerHierarchy.Container.Name,
 			Filters:         conf.DockerHierarchy.Container.Filter,
 			StartAtVersion:  conf.DockerHierarchy.Container.StartAt,
+			EndAtVersion:    conf.DockerHierarchy.Container.EndAt,
 			SkipVersions:    conf.DockerHierarchy.Container.Skips,
 			IncludeVersions: conf.DockerHierarchy.Container.Includes,
 			Path:            subpath,
@@ -175,7 +177,7 @@ func (s *DockerHierarchyParser) Update(dryrun bool) error {
 	for _, root := range s.Roots {
 
 		// Get all versions (tags) based on filters and user preferences
-		versions := GetVersions(root.Container, root.Filters, root.StartAtVersion, root.SkipVersions, root.IncludeVersions)
+		versions := GetVersions(root.Container, root.Filters, root.StartAtVersion, root.EndAtVersion, root.SkipVersions, root.IncludeVersions)
 
 		// At this point we have a list of versions we want.
 		// We now compare existing to those that need to be created

--- a/parsers/spack/spack.go
+++ b/parsers/spack/spack.go
@@ -62,7 +62,7 @@ type SpackDependency struct {
 }
 
 // Get Versions of a spack package relevant to a set of user preferences
-func (s *SpackPackage) GetVersions(filters []string, startAtVersion string, skipVersions []string, includeVersions []string) []string {
+func (s *SpackPackage) GetVersions(filters []string, startAtVersion string, endAtVersion string, skipVersions []string, includeVersions []string) []string {
 
 	// Sort versions from earliest to latest
 	contenders := []string{}
@@ -73,5 +73,5 @@ func (s *SpackPackage) GetVersions(filters []string, startAtVersion string, skip
 	// Sort from least to greatest
 	sort.Sort(sort.Reverse(sort.StringSlice(contenders)))
 
-	return parsers.GetVersions(contenders, filters, startAtVersion, skipVersions, includeVersions)
+	return parsers.GetVersions(contenders, filters, startAtVersion, endAtVersion, skipVersions, includeVersions)
 }


### PR DESCRIPTION
This adds the twin to 'startat' to ensure we can stop at a version.

Signed-off-by: vsoch <vsoch@users.noreply.github.com>